### PR TITLE
Add month view to schedule

### DIFF
--- a/src/components/SchedulingPanel.tsx
+++ b/src/components/SchedulingPanel.tsx
@@ -1,6 +1,15 @@
 import React, { useState } from 'react';
 import { Calendar, Clock, Users, Plus, Video, Book, Heart, Settings } from 'lucide-react';
-import { format, addDays, startOfWeek, addWeeks } from 'date-fns';
+import {
+  format,
+  addDays,
+  startOfWeek,
+  endOfWeek,
+  addWeeks,
+  startOfMonth,
+  endOfMonth,
+  addMonths,
+} from 'date-fns';
 import { useApp } from '../context/AppContext';
 
 interface Meeting {
@@ -26,6 +35,15 @@ export function SchedulingPanel() {
 
   const weekStart = startOfWeek(selectedDate);
   const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+
+  const monthStart = startOfMonth(selectedDate);
+  const monthEnd = endOfMonth(selectedDate);
+  const monthStartDate = startOfWeek(monthStart);
+  const monthEndDate = endOfWeek(monthEnd);
+  const monthDays: Date[] = [];
+  for (let d = monthStartDate; d <= monthEndDate; d = addDays(d, 1)) {
+    monthDays.push(d);
+  }
 
   const getMeetingsForDate = (date: Date) => {
     return state.meetings.filter(meeting =>
@@ -170,7 +188,15 @@ export function SchedulingPanel() {
           </div>
           <div className="flex items-center space-x-2">
             <button
-              onClick={() => setViewMode(viewMode === 'week' ? 'month' : 'week')}
+              onClick={() => {
+                if (viewMode === 'week') {
+                  setViewMode('month');
+                  setSelectedDate(startOfMonth(selectedDate));
+                } else {
+                  setViewMode('week');
+                  setSelectedDate(startOfWeek(selectedDate));
+                }
+              }}
               className="px-3 py-1 bg-white/20 hover:bg-white/30 rounded-lg transition-colors text-sm"
             >
               {viewMode === 'week' ? 'Month View' : 'Week View'}
@@ -185,24 +211,44 @@ export function SchedulingPanel() {
           </div>
         </div>
 
-        {/* Week Navigation */}
-        <div className="flex items-center justify-between">
-          <button
-            onClick={() => setSelectedDate(addWeeks(selectedDate, -1))}
-            className="p-2 hover:bg-white/20 rounded-lg transition-colors"
-          >
-            ←
-          </button>
-          <h3 className="text-lg font-semibold">
-            {format(weekStart, 'MMM dd')} - {format(addDays(weekStart, 6), 'MMM dd, yyyy')}
-          </h3>
-          <button
-            onClick={() => setSelectedDate(addWeeks(selectedDate, 1))}
-            className="p-2 hover:bg-white/20 rounded-lg transition-colors"
-          >
-            →
-          </button>
-        </div>
+        {/* Date Navigation */}
+        {viewMode === 'week' ? (
+          <div className="flex items-center justify-between">
+            <button
+              onClick={() => setSelectedDate(addWeeks(selectedDate, -1))}
+              className="p-2 hover:bg-white/20 rounded-lg transition-colors"
+            >
+              ←
+            </button>
+            <h3 className="text-lg font-semibold">
+              {format(weekStart, 'MMM dd')} - {format(addDays(weekStart, 6), 'MMM dd, yyyy')}
+            </h3>
+            <button
+              onClick={() => setSelectedDate(addWeeks(selectedDate, 1))}
+              className="p-2 hover:bg-white/20 rounded-lg transition-colors"
+            >
+              →
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between">
+            <button
+              onClick={() => setSelectedDate(addMonths(selectedDate, -1))}
+              className="p-2 hover:bg-white/20 rounded-lg transition-colors"
+            >
+              ←
+            </button>
+            <h3 className="text-lg font-semibold">
+              {format(selectedDate, 'MMMM yyyy')}
+            </h3>
+            <button
+              onClick={() => setSelectedDate(addMonths(selectedDate, 1))}
+              className="p-2 hover:bg-white/20 rounded-lg transition-colors"
+            >
+              →
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Calendar Grid */}
@@ -214,15 +260,22 @@ export function SchedulingPanel() {
             </div>
           ))}
           
-          {weekDays.map(day => {
+          {(viewMode === 'week' ? weekDays : monthDays).map(day => {
             const meetings = getMeetingsForDate(day);
             const isToday = format(day, 'yyyy-MM-dd') === format(new Date(), 'yyyy-MM-dd');
+            const isCurrentMonth = viewMode === 'month' ? day.getMonth() === selectedDate.getMonth() : true;
             
             return (
               <div key={day.toISOString()} className="bg-white min-h-32 p-2">
-                <div className={`text-sm font-medium mb-2 ${
-                  isToday ? 'text-primary-600' : 'text-gray-700'
-                }`}>
+                <div
+                  className={`text-sm font-medium mb-2 ${
+                    isToday
+                      ? 'text-primary-600'
+                      : isCurrentMonth
+                      ? 'text-gray-700'
+                      : 'text-gray-400'
+                  }`}
+                >
                   {format(day, 'd')}
                 </div>
                 


### PR DESCRIPTION
## Summary
- extend `SchedulingPanel` with month view logic
- add month navigation and highlight for days outside the current month
- update view toggle to reset selected date to first of month or week

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f339514fc8325a53c54a648c76dae