### PR TITLE
Use lazy loaded views with Suspense

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,7 @@ export default tseslint.config(
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
-      ecmaVersion: 2020,
+      ecmaVersion: 'latest',
       globals: globals.browser,
     },
     plugins: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,11 @@
-import React, { useState } from 'react';
+import React, { Suspense, useState } from 'react';
 import { Sidebar } from './components/Sidebar';
-import { VideoConference } from './components/VideoConference';
-import { SchedulingPanel } from './components/SchedulingPanel';
+const VideoConference = React.lazy(
+  () => import('./components/VideoConference')
+);
+const SchedulingPanel = React.lazy(
+  () => import('./components/SchedulingPanel')
+);
 import { Header } from './components/Header';
 import { AppProvider } from './context/AppContext';
 
@@ -33,11 +37,15 @@ function App() {
             collapsed={sidebarCollapsed}
             setCollapsed={setSidebarCollapsed}
           />
-          <main className={`flex-1 transition-all duration-300 ${
-            sidebarCollapsed ? 'ml-16' : 'ml-64'
-          }`}>
+          <main
+            className={`flex-1 transition-all duration-300 ${
+              sidebarCollapsed ? 'ml-16' : 'ml-64'
+            }`}
+          >
             <div className="h-full p-6">
-              {renderActiveView()}
+              <Suspense fallback={<div>Loading...</div>}>
+                {renderActiveView()}
+              </Suspense>
             </div>
           </main>
         </div>


### PR DESCRIPTION
## Summary
- lazy load the VideoConference and SchedulingPanel components
- wrap views in a Suspense boundary for simple loading indicator
- allow ESLint to parse modern syntax for dynamic imports

## Testing
- `npm run lint` *(fails: 31 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_687438ee32ac832595efef10ce5dd93e