### PR TITLE
Add basic chat system

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ The compiled files are created in `dist/`. You can preview the production build 
 npm run preview
 ```
 
+## Chat
+The video conference includes a simple chat panel powered by Socket.IO. When a meeting starts the client connects to `http://localhost:3001` to send and receive messages.
+
+To test chat locally you can run a minimal Socket.IO server:
+
+```bash
+npm install socket.io
+node - <<'SERVER'
+const { Server } = require('socket.io');
+const io = new Server(3001, { cors: { origin: '*' } });
+io.on('connection', (socket) => {
+  socket.on('message', (msg) => socket.broadcast.emit('message', msg));
+});
+SERVER
+```
+
 ## Contributing
 1. Fork this repository and create a new branch for your feature or bug fix.
 2. Install dependencies with `npm install` and run `npm run lint` before committing.

--- a/src/components/video/ChatPanel.tsx
+++ b/src/components/video/ChatPanel.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { MessageCircle, Send, X } from 'lucide-react';
+import { useApp, ChatMessage } from '../../context/AppContext';
+import { chatService } from '../../services/chat';
+
+interface ChatPanelProps {
+  onClose: () => void;
+}
+
+export function ChatPanel({ onClose }: ChatPanelProps) {
+  const { state, dispatch } = useApp();
+  const [text, setText] = useState('');
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [state.messages]);
+
+  const send = () => {
+    if (!text.trim()) return;
+    const msg: ChatMessage = {
+      id: Date.now().toString(),
+      sender: 'You',
+      text: text.trim(),
+      timestamp: new Date()
+    };
+    chatService.sendMessage(msg);
+    dispatch({ type: 'SEND_MESSAGE', payload: msg });
+    setText('');
+  };
+
+  return (
+    <div className="flex-1 flex flex-col">
+      <div className="p-4 border-b border-gray-700 flex items-center justify-between">
+        <div className="flex items-center space-x-2">
+          <MessageCircle className="w-5 h-5 text-white" />
+          <h3 className="text-white font-semibold">Chat</h3>
+        </div>
+        <button
+          onClick={onClose}
+          className="p-1 hover:bg-gray-700 rounded transition-colors"
+          title="Close chat"
+        >
+          <X className="w-4 h-4 text-gray-400" />
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-3 space-y-3 bg-gray-700/20">
+        {state.messages.map((m) => (
+          <div key={m.id} className="text-sm text-white">
+            <div className="text-xs text-gray-400 mb-1">
+              {m.sender} - {m.timestamp.toLocaleTimeString()}
+            </div>
+            <div>{m.text}</div>
+          </div>
+        ))}
+        <div ref={messagesEndRef} />
+      </div>
+      <div className="p-3 border-t border-gray-700 flex items-center space-x-2">
+        <input
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && send()}
+          className="flex-1 bg-gray-600 text-white rounded p-2 text-sm focus:outline-none"
+          placeholder="Type a message"
+        />
+        <button
+          onClick={send}
+          className="p-2 bg-blue-600 hover:bg-blue-700 rounded text-white"
+        >
+          <Send className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/video/VideoControls.tsx
+++ b/src/components/video/VideoControls.tsx
@@ -10,14 +10,16 @@ interface VideoControlsProps {
   onToggleMute?: () => void;
   onScreenShare?: () => void;
   onShareVerse?: () => void;
+  onToggleChat?: () => void;
 }
 
-export function VideoControls({ 
-  onLeaveMeeting, 
-  onToggleVideo, 
-  onToggleMute, 
+export function VideoControls({
+  onLeaveMeeting,
+  onToggleVideo,
+  onToggleMute,
   onScreenShare,
-  onShareVerse
+  onShareVerse,
+  onToggleChat
 }: VideoControlsProps) {
   const { state, dispatch } = useApp();
   const [showScreenShareMenu, setShowScreenShareMenu] = useState(false);
@@ -128,10 +130,10 @@ export function VideoControls({
     },
     {
       icon: MessageCircle,
-      label: 'Chat (coming soon)',
+      label: 'Chat',
       active: false,
-      disabled: true,
-      className: 'bg-gray-600 hover:bg-gray-500 opacity-50 cursor-not-allowed'
+      onClick: () => onToggleChat && onToggleChat(),
+      className: 'bg-gray-600 hover:bg-gray-500'
     },
     {
       icon: Settings,

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -1,0 +1,29 @@
+import { io, Socket } from 'socket.io-client';
+import type { ChatMessage } from '../context/AppContext';
+
+class ChatService {
+  private socket: Socket | null = null;
+  public onMessage?: (msg: ChatMessage) => void;
+
+  connect(meetingId: string) {
+    this.socket = io('http://localhost:3001', { query: { meetingId } });
+    this.socket.on('message', (data: ChatMessage) => {
+      const msg: ChatMessage = {
+        ...data,
+        timestamp: new Date(data.timestamp)
+      };
+      this.onMessage?.(msg);
+    });
+  }
+
+  sendMessage(message: ChatMessage) {
+    this.socket?.emit('message', message);
+  }
+
+  disconnect() {
+    this.socket?.disconnect();
+    this.socket = null;
+  }
+}
+
+export const chatService = new ChatService();


### PR DESCRIPTION
## Summary
- extend `AppState` with chat messages and actions
- create ChatPanel UI and chat service via socket.io
- connect chat service in VideoConference
- enable chat button in video controls
- document chat usage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68743dc3617c8325a5d95f393748cee3