### PR TITLE
Handle recipientId for chat messages

### DIFF
--- a/src/components/video/ChatPanel.tsx
+++ b/src/components/video/ChatPanel.tsx
@@ -22,7 +22,8 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
       id: Date.now().toString(),
       sender: 'You',
       text: text.trim(),
-      timestamp: new Date()
+      timestamp: new Date(),
+      recipientId: null
     };
     chatService.sendMessage(msg);
     dispatch({ type: 'SEND_MESSAGE', payload: msg });

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -40,6 +40,7 @@ export interface ChatMessage {
   sender: string;
   text: string;
   timestamp: Date;
+  recipientId: string | null;
 }
 
 interface AppState {
@@ -170,12 +171,18 @@ function appReducer(state: AppState, action: AppAction): AppState {
     case 'SEND_MESSAGE':
       return {
         ...state,
-        messages: [...state.messages, action.payload]
+        messages: [
+          ...state.messages,
+          { ...action.payload, recipientId: action.payload.recipientId ?? null }
+        ]
       };
     case 'RECEIVE_MESSAGE':
       return {
         ...state,
-        messages: [...state.messages, action.payload]
+        messages: [
+          ...state.messages,
+          { ...action.payload, recipientId: action.payload.recipientId ?? null }
+        ]
       };
     default:
       return state;
@@ -215,10 +222,14 @@ export function AppProvider({ children }: { children: ReactNode }) {
                   timestamp: new Date((parsed.sharedVerse as SharedVerse).timestamp)
                 }
               : null,
-            messages: (parsed.messages ?? []).map((m) => ({
-              ...(m as ChatMessage),
-              timestamp: new Date((m as ChatMessage).timestamp)
-            }))
+            messages: (parsed.messages ?? []).map((m) => {
+              const msg = m as Partial<ChatMessage> & { timestamp: string };
+              return {
+                ...msg,
+                timestamp: new Date(msg.timestamp),
+                recipientId: msg.recipientId ?? null
+              } as ChatMessage;
+            })
           } as AppState;
         }
       } catch (err) {

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -10,7 +10,8 @@ class ChatService {
     this.socket.on('message', (data: ChatMessage) => {
       const msg: ChatMessage = {
         ...data,
-        timestamp: new Date(data.timestamp)
+        timestamp: new Date((data as any).timestamp),
+        recipientId: (data as any).recipientId ?? null
       };
       this.onMessage?.(msg);
     });


### PR DESCRIPTION
## Summary
- support direct message field on chat messages
- persist recipient info in localStorage when parsing
- include recipientId when sending or receiving chat messages

## Testing
- `npm run lint` *(fails: 33 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6874415b3e648325866b681c0bf7bc43