### PR TITLE
Add private messaging to chat service

### DIFF
--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -7,17 +7,24 @@ class ChatService {
 
   connect(meetingId: string) {
     this.socket = io('http://localhost:3001', { query: { meetingId } });
-    this.socket.on('message', (data: ChatMessage) => {
+    const handler = (data: ChatMessage) => {
       const msg: ChatMessage = {
         ...data,
         timestamp: new Date(data.timestamp)
       };
       this.onMessage?.(msg);
-    });
+    };
+
+    this.socket.on('message', handler);
+    this.socket.on('private-message', handler);
   }
 
   sendMessage(message: ChatMessage) {
     this.socket?.emit('message', message);
+  }
+
+  sendPrivateMessage(message: ChatMessage) {
+    this.socket?.emit('private-message', message);
   }
 
   disconnect() {


### PR DESCRIPTION
## Summary
- extend chat service with private messaging
- connect to both public and private message events

## Testing
- `npm run lint` *(fails: cannot pass ESLint due to existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_6874415e98488325b5c0387ec7ceebd4