### PR TITLE
Add private messaging dropdown

### DIFF
--- a/src/components/video/ChatPanel.tsx
+++ b/src/components/video/ChatPanel.tsx
@@ -10,6 +10,7 @@ interface ChatPanelProps {
 export function ChatPanel({ onClose }: ChatPanelProps) {
   const { state, dispatch } = useApp();
   const [text, setText] = useState('');
+  const [recipientId, setRecipientId] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -22,9 +23,14 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
       id: Date.now().toString(),
       sender: 'You',
       text: text.trim(),
-      timestamp: new Date()
+      timestamp: new Date(),
+      recipientId
     };
-    chatService.sendMessage(msg);
+    if (recipientId) {
+      chatService.sendPrivateMessage(recipientId, msg);
+    } else {
+      chatService.sendMessage(msg);
+    }
     dispatch({ type: 'SEND_MESSAGE', payload: msg });
     setText('');
   };
@@ -56,6 +62,20 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
         <div ref={messagesEndRef} />
       </div>
       <div className="p-3 border-t border-gray-700 flex items-center space-x-2">
+        <select
+          value={recipientId ?? ''}
+          onChange={(e) =>
+            setRecipientId(e.target.value ? e.target.value : null)
+          }
+          className="bg-gray-600 text-white rounded p-2 text-sm focus:outline-none"
+        >
+          <option value="">Everyone</option>
+          {state.participants.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
         <input
           type="text"
           value={text}

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -40,6 +40,7 @@ export interface ChatMessage {
   sender: string;
   text: string;
   timestamp: Date;
+  recipientId?: string | null;
 }
 
 interface AppState {

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -14,10 +14,21 @@ class ChatService {
       };
       this.onMessage?.(msg);
     });
+    this.socket.on('privateMessage', (data: ChatMessage) => {
+      const msg: ChatMessage = {
+        ...data,
+        timestamp: new Date(data.timestamp)
+      };
+      this.onMessage?.(msg);
+    });
   }
 
   sendMessage(message: ChatMessage) {
     this.socket?.emit('message', message);
+  }
+
+  sendPrivateMessage(recipientId: string, message: ChatMessage) {
+    this.socket?.emit('privateMessage', { ...message, recipientId });
   }
 
   disconnect() {


### PR DESCRIPTION
## Summary
- support private messages in context
- handle private messaging in chat service
- allow choosing private chat recipient in chat panel

## Testing
- `npm run lint` *(fails: various eslint errors)*
- `npm run build`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6874415fb9e48325bd1b7e0e2685357d